### PR TITLE
Add appsource server to constd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,7 @@ run:
 constd:
 	go build -o .bin/constd -tags netgo -ldflags="-extldflags=-static" ./constd
 
+constd/dev:
+	CONSTD_SAT_TAG=dev .bin/constd $(PWD)/constd/example-project/runnables.wasm.zip
+
 .PHONY: sat constd

--- a/constd/appsource.go
+++ b/constd/appsource.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"github.com/pkg/errors"
+	"github.com/suborbital/atmo/atmo/appsource"
+	"github.com/suborbital/atmo/atmo/options"
+	"github.com/suborbital/vektor/vk"
+)
+
+func startAppSourceServer(bundlePath string) (appsource.AppSource, chan error) {
+	app := appsource.NewBundleSource(bundlePath)
+	opts := options.NewWithModifiers()
+
+	errchan := make(chan error)
+
+	router, err := appsource.NewAppSourceVKRouter(app, *opts).GenerateRouter()
+	if err != nil {
+		errchan <- errors.Wrap(err, "failed to NewAppSourceVKRouter.GenerateRouter")
+	}
+
+	server := vk.New(
+		vk.UseAppName("constd server"),
+		vk.UseHTTPPort(9090),
+		vk.UseEnvPrefix("CONSTD"),
+	)
+
+	server.SwapRouter(router)
+
+	go func() {
+		if err := server.Start(); err != nil {
+			errchan <- errors.Wrap(err, "failed to server.Start")
+		}
+	}()
+
+	return app, errchan
+}

--- a/constd/main.go
+++ b/constd/main.go
@@ -2,19 +2,14 @@ package main
 
 import (
 	"crypto/rand"
-	"crypto/sha256"
-	"encoding/base64"
 	"fmt"
-	"io"
 	"log"
 	"math/big"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/pkg/errors"
-	"github.com/suborbital/atmo/bundle"
-	"github.com/suborbital/atmo/directive"
+	"github.com/suborbital/atmo/atmo/appsource"
 	"github.com/suborbital/subo/subo/util"
 )
 
@@ -25,38 +20,38 @@ func main() {
 
 	bundlePath := os.Args[1]
 
-	startAtmo(bundlePath)
+	appSource, errchan := startAppSourceServer(bundlePath)
 
-	directive, err := unloadBundle(bundlePath)
-	if err != nil {
-		log.Fatal(errors.Wrap(err, "failed to unloadBundle"))
+	startAtmo(bundlePath, errchan)
+
+	startConstellation(appSource, errchan)
+
+	// assuming nothing above throws an error, this will block forever
+	if err := <-errchan; err != nil {
+		log.Fatal(errors.Wrap(err, "failed to startAppSourceServer"))
 	}
-
-	startConstellation(directive)
-
-	<-time.After(time.Hour)
 }
 
-func startAtmo(bundlePath string) {
+func startAtmo(bundlePath string, errchan chan error) {
 	mountPath := filepath.Dir(bundlePath)
 
 	go func() {
-		if _, err := util.Run(fmt.Sprintf("docker run -p 8080:8080 -e ATMO_HTTP_PORT=8080 -v %s:/home/atmo --network bridge suborbital/atmo-proxy:dev atmo-proxy", mountPath)); err != nil {
-			log.Fatal(errors.Wrap(err, "failed to Run Atmo"))
+		if _, err := util.Run(fmt.Sprintf("docker run -p 8080:8080 -e ATMO_HTTP_PORT=8080 -e ATMO_CONTROL_PLANE=docker.for.mac.localhost:9090 -v %s:/home/atmo --network bridge suborbital/atmo-proxy:dev atmo-proxy", mountPath)); err != nil {
+			errchan <- errors.Wrap(err, "failed to Run Atmo")
 		}
 	}()
 }
 
-func startConstellation(directive *directive.Directive) {
+func startConstellation(appSource appsource.AppSource, errchan chan error) {
 	satTag := "latest"
 	if tag, exists := os.LookupEnv("CONSTD_SAT_TAG"); exists {
 		satTag = tag
 	}
 
-	folderPath := filepath.Join(os.TempDir(), "suborbital", directiveFileHash(directive))
+	runnables := appSource.Runnables()
 
-	for i := range directive.Runnables {
-		runnable := directive.Runnables[i]
+	for i := range runnables {
+		runnable := runnables[i]
 
 		go func() {
 			fmt.Printf("launching %s\n", runnable.FQFN)
@@ -67,66 +62,20 @@ func startConstellation(directive *directive.Directive) {
 			}
 
 			for {
-				// build this monstrosity of an exec string
 				_, err := util.Run(fmt.Sprintf(
-					"docker run --rm -p %s:%s -e SAT_HTTP_PORT=%s -v %s:/runnables --network bridge --name %s suborbital/sat:%s sat %s.wasm",
+					"docker run --rm -p %s:%s -e SAT_HTTP_PORT=%s -e SAT_CONTROL_PLANE=docker.for.mac.localhost:9090 --network bridge --name %s suborbital/sat:%s sat %s",
 					port, port, port,
-					folderPath,
 					runnable.Name,
 					satTag,
-					filepath.Join("/runnables", runnable.FQFN),
+					runnable.FQFN,
 				))
 
 				if err != nil {
-					io.WriteString(os.Stderr, errors.Wrap(err, "sat exited with error").Error()+"\n")
+					errchan <- errors.Wrap(err, "sat exited with error")
 				}
-
-				time.Sleep(time.Millisecond * 500)
 			}
 		}()
 	}
-}
-
-func unloadBundle(bundlePath string) (*directive.Directive, error) {
-	bundle, err := bundle.Read(bundlePath)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to bundle.Read")
-	}
-
-	if err := bundle.Directive.Validate(); err != nil {
-		return nil, errors.Wrap(err, "failed to Validate Directive")
-	}
-
-	folderPath := filepath.Join(os.TempDir(), "suborbital", directiveFileHash(bundle.Directive))
-
-	// check if the folder already exists
-	if _, err := os.Stat(folderPath); err != nil {
-		if err := os.RemoveAll(folderPath); err != nil {
-			return nil, errors.Wrap(err, "failed to RemoveAll existing bundle")
-		}
-	}
-
-	if err := os.MkdirAll(folderPath, os.ModePerm); err != nil {
-		return nil, errors.Wrap(err, "faield to MkdirAll for bundle")
-	}
-
-	for _, r := range bundle.Directive.Runnables {
-		filename := filepath.Join(folderPath, fmt.Sprintf("%s.wasm", r.FQFN))
-
-		if err := os.WriteFile(filename, r.ModuleRef.Data, os.ModePerm); err != nil {
-			return nil, errors.Wrapf(err, "failed to WriteFile for %s", r.FQFN)
-		}
-	}
-
-	return bundle.Directive, nil
-}
-
-func directiveFileHash(directive *directive.Directive) string {
-	sha := sha256.New()
-	sha.Write([]byte(directive.Identifier))
-	sha.Write([]byte(directive.AppVersion))
-
-	return base64.URLEncoding.EncodeToString(sha.Sum(nil))
 }
 
 func randPort() (string, error) {

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.10.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
@@ -31,19 +30,9 @@ require (
 	github.com/jackc/pgx/v4 v4.14.1 // indirect
 	github.com/jmoiron/sqlx v1.3.4 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
-	github.com/klauspost/compress v1.13.5 // indirect
-	github.com/nats-io/nats.go v1.13.0 // indirect
-	github.com/nats-io/nkeys v0.3.0 // indirect
-	github.com/nats-io/nuid v1.0.1 // indirect
-	github.com/pierrec/lz4/v4 v4.1.8 // indirect
 	github.com/schollz/peerdiscovery v1.6.9 // indirect
 	github.com/second-state/WasmEdge-go v0.9.0 // indirect
 	github.com/sethvargo/go-envconfig v0.4.0 // indirect
-	github.com/spf13/cobra v1.2.1 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/twmb/franz-go v1.2.3 // indirect
-	github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211104051938-70808186d5f7 // indirect
-	github.com/twmb/go-rbtree v1.0.0 // indirect
 	github.com/wasmerio/wasmer-go v1.0.4 // indirect
 	golang.org/x/crypto v0.0.0-20211202192323-5770296d904e // indirect
 	golang.org/x/mod v0.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -219,7 +219,6 @@ github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/J
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
@@ -294,7 +293,6 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.11.12/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
-github.com/klauspost/compress v1.13.5 h1:9O69jUPDcsT9fEm74W92rZL9FQY7rCdaXVneq+yyzl4=
 github.com/klauspost/compress v1.13.5/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -345,12 +343,9 @@ github.com/nats-io/jwt/v2 v2.0.2/go.mod h1:VRP+deawSXyhNjXmxPCHskrR6Mq50BqpEI5SE
 github.com/nats-io/jwt/v2 v2.2.0/go.mod h1:0tqz9Hlu6bCBFLWAASKhE5vUA4c24L9KPUUgvwumE/k=
 github.com/nats-io/nats-server/v2 v2.3.2/go.mod h1:dUf7Cm5z5LbciFVwWx54owyCKm8x4/hL6p7rrljhLFY=
 github.com/nats-io/nats.go v1.11.1-0.20210623165838-4b75fc59ae30/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
-github.com/nats-io/nats.go v1.13.0 h1:LvYqRB5epIzZWQp6lmeltOOZNLqCvm4b+qfvzZO03HE=
 github.com/nats-io/nats.go v1.13.0/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nkeys v0.2.0/go.mod h1:XdZpAbhgyyODYqjTawOnIOI7VlbKSarI9Gfy1tqEu/s=
-github.com/nats-io/nkeys v0.3.0 h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=
 github.com/nats-io/nkeys v0.3.0/go.mod h1:gvUNGjVcM2IPr5rCsRsC6Wb3Hr2CQAm08dsxtV6A5y4=
-github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
@@ -368,7 +363,6 @@ github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
-github.com/pierrec/lz4/v4 v4.1.8 h1:ieHkV+i2BRzngO4Wd/3HGowuZStgq6QkPsD1eolNAO4=
 github.com/pierrec/lz4/v4 v4.1.8/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -424,12 +418,10 @@ github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
-github.com/spf13/cobra v1.2.1 h1:+KmjbUw1hriSNMF55oPrkZcb27aECyrj8V2ytv7kWDw=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
@@ -452,12 +444,6 @@ github.com/suborbital/atmo v0.2.4-0.20210703165749-14c9326b2f7f/go.mod h1:Wt+gmD
 github.com/suborbital/atmo v0.3.1-0.20210810195347-325b9aa81ca7/go.mod h1:fqKzibuuvELT05PdPQhiKPdYuSkQ01ThBYRwhwS/UkQ=
 github.com/suborbital/atmo v0.3.1-0.20210811161300-cf9b7d3fbb19/go.mod h1:p8Myr6lgyUiGcGczf9XEhhW1RVFgwnCYGEtZJ+tMSIg=
 github.com/suborbital/atmo v0.3.2/go.mod h1:IxnfL5KlvLFs/O8q5XjCpFP6jSXpmSIfArKXUiVNEc8=
-github.com/suborbital/atmo v0.4.3-0.20211209220705-9c4b1ba8b0cb h1:AwiEKX/bVVML0/ZgC8Rkf1l9hBB/ljaX6YBokGIIKZ4=
-github.com/suborbital/atmo v0.4.3-0.20211209220705-9c4b1ba8b0cb/go.mod h1:fU70lBcFAzRK9tNvXLTdmfB1YNwvkVskhhi5Y5buMTI=
-github.com/suborbital/atmo v0.4.3-0.20211212174411-1e32941d4c9c h1:PnxzxfDtrg0Ck1fLcjNfO7N7ZouveHciFwJ5e6rBcus=
-github.com/suborbital/atmo v0.4.3-0.20211212174411-1e32941d4c9c/go.mod h1:fU70lBcFAzRK9tNvXLTdmfB1YNwvkVskhhi5Y5buMTI=
-github.com/suborbital/atmo v0.4.3-0.20211212183327-e51acad6f78c h1:bkBQFLmtcWZiY+KtUedxOrHhTe9zlTu/D7isJk2YWiI=
-github.com/suborbital/atmo v0.4.3-0.20211212183327-e51acad6f78c/go.mod h1:fU70lBcFAzRK9tNvXLTdmfB1YNwvkVskhhi5Y5buMTI=
 github.com/suborbital/atmo v0.4.3-0.20211212184131-ffd6ad1ee4e0 h1:w2/0cpVosIfJX1uBQtP/0jhpA5c7gBaaBDzsnJPNAb0=
 github.com/suborbital/atmo v0.4.3-0.20211212184131-ffd6ad1ee4e0/go.mod h1:fU70lBcFAzRK9tNvXLTdmfB1YNwvkVskhhi5Y5buMTI=
 github.com/suborbital/grav v0.3.0/go.mod h1:PapJ62PtT9dPmW37WaCD+UMhoZiNPp0N9E3nUfEujC4=
@@ -497,11 +483,8 @@ github.com/suborbital/wasmtime-go v0.31.0-subo h1:RRtQK/Japgqi6cAi3XBPmYF9laqW7h
 github.com/suborbital/wasmtime-go v0.31.0-subo/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/twmb/franz-go v1.2.3 h1:K4Zommxo0qZuNnKEt4CcunHPLKdqDCUhcwoU+YdvQjo=
 github.com/twmb/franz-go v1.2.3/go.mod h1:e5ZOdNswX/wv+jebWNX49yc9U7zgR18Xovj9ckk6mx8=
-github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211104051938-70808186d5f7 h1:YW4mW39H53O1qouKQnlrdNwyqAi5c4P10Oig8yndDKQ=
 github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211104051938-70808186d5f7/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
-github.com/twmb/go-rbtree v1.0.0 h1:KxN7dXJ8XaZ4cvmHV1qqXTshxX3EBvX/toG5+UR49Mg=
 github.com/twmb/go-rbtree v1.0.0/go.mod h1:UlIAI8gu3KRPkXSobZnmJfVwCJgEhD/liWzT5ppzIyc=
 github.com/wasmerio/wasmer-go v1.0.3/go.mod h1:0gzVdSfg6pysA6QVp6iVRPTagC6Wq9pOE8J86WKb2Fk=
 github.com/wasmerio/wasmer-go v1.0.4 h1:MnqHoOGfiQ8MMq2RF6wyCeebKOe84G88h5yv+vmxJgs=

--- a/sat/config.go
+++ b/sat/config.go
@@ -46,6 +46,7 @@ func configFromArgs(logger *vlog.Logger) (*config, error) {
 
 	var runnable *directive.Runnable
 
+	// first, determine if we need to connect to a control plane
 	controlPlane, useControlPlane := os.LookupEnv("SAT_CONTROL_PLANE")
 	appClient := appsource.NewHTTPSource(controlPlane)
 	caps := rcap.DefaultConfigWithLogger(logger)
@@ -66,7 +67,7 @@ func configFromArgs(logger *vlog.Logger) (*config, error) {
 		caps = rendered
 	}
 
-	// handle the runnable arg being a URL, an FQFN, or a path on disk
+	// next, handle the runnable arg being a URL, an FQFN, or a path on disk
 	if isURL(runnableArg) {
 		logger.Debug("fetching module from URL")
 		tmpFile, err := downloadFromURL(runnableArg)
@@ -104,6 +105,7 @@ func configFromArgs(logger *vlog.Logger) (*config, error) {
 		runnable = diskRunnable
 	}
 
+	// next, figure out the configuration of the HTTP server
 	port, ok := os.LookupEnv("SAT_HTTP_PORT")
 	if !ok {
 		// choose a random port above 1000
@@ -119,6 +121,7 @@ func configFromArgs(logger *vlog.Logger) (*config, error) {
 
 	runnableName := strings.TrimSuffix(filepath.Base(runnableArg), ".wasm")
 
+	// finally, put it all together
 	c := &config{
 		runnableArg:     runnableArg,
 		runnableName:    runnableName,

--- a/sat/main.go
+++ b/sat/main.go
@@ -2,17 +2,23 @@ package main
 
 import (
 	"log"
-	"os"
+
+	"github.com/suborbital/vektor/vlog"
 )
 
 func main() {
-	config, err := configFromArgs(os.Args)
+	// logger for Sat, rwasm runtime, and Runnable output
+	logger := vlog.Default(
+		vlog.EnvPrefix("SAT"),
+	)
+
+	config, err := configFromArgs(logger)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// initialize Reactr, Vektor, and Grav and wrap them in a sat instance
-	s, err := initSat(config)
+	s, err := initSat(logger, config)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/sat/sat.go
+++ b/sat/sat.go
@@ -9,16 +9,11 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
-	"github.com/suborbital/atmo/atmo/appsource"
-	"github.com/suborbital/atmo/atmo/coordinator/capabilities"
 	"github.com/suborbital/atmo/atmo/coordinator/executor"
 	"github.com/suborbital/atmo/atmo/coordinator/sequence"
-	"github.com/suborbital/atmo/atmo/options"
-	"github.com/suborbital/atmo/fqfn"
 	"github.com/suborbital/grav/discovery/local"
 	"github.com/suborbital/grav/grav"
 	"github.com/suborbital/grav/transport/websocket"
-	"github.com/suborbital/reactr/rcap"
 	"github.com/suborbital/reactr/request"
 	"github.com/suborbital/reactr/rt"
 	"github.com/suborbital/reactr/rwasm"
@@ -39,63 +34,37 @@ type sat struct {
 	g *grav.Grav
 	e *executor.Executor
 	l *vlog.Logger
-	a appsource.AppSource
 }
 
 var wait bool = false
+var headless bool = false
 
 // initSat initializes Reactr, Vektor, and Grav instances
 // if config.useStdin is true, only Reactr will be created, returning r, nil, nil
-func initSat(config *config) (*sat, error) {
-	// logger for Sat, rwasm runtime, and Runnable output
-	logger := vlog.Default(
-		vlog.EnvPrefix("SAT"),
-	)
-
+func initSat(logger *vlog.Logger, config *config) (*sat, error) {
 	runtime.UseInternalLogger(logger)
 
 	// first configure this instance's 'identity'
 	jobName := config.runnableName
-
-	if config.runnable != nil {
-		ident, iExists := os.LookupEnv("SAT_RUNNABLE_IDENT")
-		version, vExists := os.LookupEnv("SAT_RUNNABLE_VERSION")
-		if iExists && vExists {
-			logger.Debug("configuring with .runnable.yaml")
-			jobName = fqfn.FromParts(ident, config.runnable.Namespace, config.runnable.Name, version)
-		}
+	if config.runnable.FQFN != "" {
+		jobName = config.runnable.FQFN
 	}
 
 	logger.Debug("registering", jobName)
 
-	// next, determine if config should be fetched from a control plane
-	var appSource appsource.AppSource
-	caps := rcap.DefaultConfigWithLogger(logger)
-
-	if config.controlPlaneUrl != "" {
-		appSource = appsource.NewHTTPSource(config.controlPlaneUrl)
-
-		// configure the appSource not to wait if the controlPlane isn't available
-		opts := options.Options{Logger: logger, Wait: &wait}
-
-		if err := appSource.Start(opts); err != nil {
-			return nil, errors.Wrap(err, "failed to appSource.Start")
-		}
-
-		rendered, err := capabilities.Render(caps, appSource, logger)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to capabilities.Render")
-		}
-
-		caps = rendered
-	}
-
 	exec := executor.NewWithGrav(logger, nil)
-	exec.UseCapabilityConfig(caps)
+	exec.UseCapabilityConfig(config.capConfig)
+
+	var runner rt.Runnable
+	if len(config.runnable.ModuleRef.Data) != 0 {
+		runner = rwasm.NewRunnerWithRef(config.runnable.ModuleRef)
+	} else {
+		runner = rwasm.NewRunner(config.runnableArg)
+	}
 
 	exec.Register(
 		jobName,
-		rwasm.NewRunner(config.modulePath),
+		runner,
 		rt.Autoscale(0),
 		rt.MaxRetries(0),
 		rt.RetrySeconds(0),
@@ -106,7 +75,6 @@ func initSat(config *config) (*sat, error) {
 		j: jobName,
 		e: exec,
 		l: logger,
-		a: appSource,
 	}
 
 	// no need to continue setup if we're in stdin mode, so return here
@@ -319,8 +287,6 @@ func (s *sat) sendFnResult(pod *grav.Pod, result *sequence.FnResult, ctx *vk.Ctx
 	if err != nil {
 		return errors.Wrap(err, "failed to Marshal function result")
 	}
-
-	fmt.Println("RESULT:", string(fnrJSON))
 
 	s.l.Info("function", s.j, "completed, sending result")
 

--- a/sat/sat.go
+++ b/sat/sat.go
@@ -56,7 +56,7 @@ func initSat(logger *vlog.Logger, config *config) (*sat, error) {
 	exec.UseCapabilityConfig(config.capConfig)
 
 	var runner rt.Runnable
-	if len(config.runnable.ModuleRef.Data) != 0 {
+	if config.runnable != nil && len(config.runnable.ModuleRef.Data) > 0 {
 		runner = rwasm.NewRunnerWithRef(config.runnable.ModuleRef)
 	} else {
 		runner = rwasm.NewRunner(config.runnableArg)

--- a/sat/sat.go
+++ b/sat/sat.go
@@ -46,7 +46,7 @@ func initSat(logger *vlog.Logger, config *config) (*sat, error) {
 
 	// first configure this instance's 'identity'
 	jobName := config.runnableName
-	if config.runnable.FQFN != "" {
+	if config.runnable != nil && config.runnable.FQFN != "" {
 		jobName = config.runnable.FQFN
 	}
 


### PR DESCRIPTION
This makes a few key changes:

- Constd now acts as an AppSource server (control plane) for Sat and Atmo-proxy
- Sat now connects to said server to download config and module data
- Atmo-proxy now does the same
- The Docker for Mac loopback interface is used for these connections