### PR TITLE
feat(constd): self-register with configured control plane

### DIFF
--- a/constd/appsource.go
+++ b/constd/appsource.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/suborbital/atmo/atmo/appsource"
 	"github.com/suborbital/atmo/atmo/options"
@@ -33,4 +35,23 @@ func startAppSourceServer(bundlePath string) (appsource.AppSource, chan error) {
 	}()
 
 	return app, errchan
+}
+
+func startAppSourceWithRetry(source appsource.AppSource) error {
+	backoffMS := float32(500)
+
+	var err error
+
+	i := 0
+	for i < 5 {
+		if err = source.Start(*options.NewWithModifiers()); err == nil {
+			break
+		}
+
+		time.Sleep(time.Millisecond * time.Duration(backoffMS))
+		backoffMS *= 1.4
+		i++
+	}
+
+	return err
 }

--- a/constd/main.go
+++ b/constd/main.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/suborbital/atmo/atmo/appsource"
-	"github.com/suborbital/atmo/atmo/options"
 	"github.com/suborbital/sat/constd/exec"
 	"github.com/suborbital/vektor/vlog"
 )
@@ -61,8 +60,8 @@ func main() {
 	} else {
 		appSource = appsource.NewHTTPSource(c.config.controlPlane)
 
-		if err := appSource.Start(*options.NewWithModifiers()); err != nil {
-			log.Fatal(errors.Wrap(err, "failed to appSource.Start"))
+		if err := startAppSourceWithRetry(appSource); err != nil {
+			log.Fatal(errors.Wrap(err, "failed to startAppSourceHTTPClient"))
 		}
 
 		if err := registerWithControlPlane(c.config); err != nil {

--- a/constd/main.go
+++ b/constd/main.go
@@ -203,7 +203,7 @@ func loadConfig() (*config, error) {
 	}
 
 	controlPlane := defaultControlPlane
-	if cp, eExists := os.LookupEnv("CONSTD_CONTROL_PLANE"); eExists {
+	if cp, cExists := os.LookupEnv("CONSTD_CONTROL_PLANE"); cExists {
 		controlPlane = cp
 	}
 

--- a/constd/main.go
+++ b/constd/main.go
@@ -65,6 +65,10 @@ func main() {
 			log.Fatal(errors.Wrap(err, "failed to appSource.Start"))
 		}
 
+		if err := registerWithControlPlane(c.config); err != nil {
+			log.Fatal(errors.Wrap(err, "failed to registerWithControlPlane"))
+		}
+
 		errchan = make(chan error)
 	}
 

--- a/constd/main.go
+++ b/constd/main.go
@@ -31,6 +31,7 @@ type config struct {
 	atmoTag      string
 	controlPlane string
 	envToken     string
+	upstreamHost string
 }
 
 func main() {
@@ -212,6 +213,11 @@ func loadConfig() (*config, error) {
 		envToken = et
 	}
 
+	upstreamHost := ""
+	if uh, uExists := os.LookupEnv("CONSTD_UPSTREAM_HOST"); uExists {
+		upstreamHost = uh
+	}
+
 	var bundlePath string
 
 	if controlPlane == defaultControlPlane && len(os.Args) < 2 {
@@ -227,6 +233,7 @@ func loadConfig() (*config, error) {
 		atmoTag:      atmoVersion,
 		controlPlane: controlPlane,
 		envToken:     envToken,
+		upstreamHost: upstreamHost,
 	}
 
 	return c, nil

--- a/constd/register.go
+++ b/constd/register.go
@@ -1,27 +1,95 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 
 	"github.com/pkg/errors"
 )
 
-func registerWithEDP(config *config) error {
+// AddUpstreamRequest is a request to add an upstream
+type AddUpstreamRequest struct {
+	UpstreamAddress string `json:"upstreamAddress"`
+}
+
+func registerWithControlPlane(config *config) error {
 	if config.controlPlane == defaultControlPlane {
 		return nil
 	}
 
-	registerURL := fmt.Sprintf("%s/upstream/register", config.controlPlane)
-
-	req, err := http.NewRequest(http.MethodPost, registerURL, nil)
+	selfIPs, err := getSelfIPAddress()
 	if err != nil {
-		return errors.Wrap(err, "failed to NewRequest")
+		return errors.Wrap(err, "failed to getSelfIPAddress")
 	}
 
-	if _, err := http.DefaultClient.Do(req); err != nil {
-		return errors.Wrap(err, "failed to Do request")
+	registerURL := fmt.Sprintf("%s/api/v1/upstream/register", config.controlPlane)
+
+	for _, ip := range selfIPs {
+		upstreamURL, err := url.Parse(fmt.Sprintf("http://%s:%s", ip.String(), atmoPort))
+		if err != nil {
+			return errors.Wrap(err, "failed to Parse")
+		}
+
+		payload := &AddUpstreamRequest{
+			UpstreamAddress: upstreamURL.Host,
+		}
+
+		bodyJSON, err := json.Marshal(payload)
+		if err != nil {
+			return errors.Wrap(err, "failed to Marshal")
+		}
+
+		req, err := http.NewRequest(http.MethodPost, registerURL, bytes.NewBuffer(bodyJSON))
+		if err != nil {
+			return errors.Wrap(err, "failed to NewRequest")
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return errors.Wrap(err, "failed to Do request")
+		}
+
+		if resp.StatusCode != http.StatusCreated {
+			return errors.New("registration request failed: " + resp.Status)
+		}
 	}
 
 	return nil
+}
+
+func getSelfIPAddress() ([]net.IP, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to Interfaces")
+	}
+
+	ips := []net.IP{}
+
+	for _, i := range ifaces {
+		addrs, err := i.Addrs()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to Addrs")
+		}
+
+		for _, addr := range addrs {
+			var ip net.IP
+
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+
+			if !ip.IsLoopback() && ip.IsPrivate() && ip.To4() != nil {
+				ips = append(ips, ip)
+			}
+		}
+	}
+
+	return ips, nil
 }

--- a/constd/register.go
+++ b/constd/register.go
@@ -21,9 +21,16 @@ func registerWithControlPlane(config *config) error {
 		return nil
 	}
 
-	selfIPs, err := getSelfIPAddress()
-	if err != nil {
-		return errors.Wrap(err, "failed to getSelfIPAddress")
+	var selfIPs []net.IP
+	if config.upstreamHost != "" {
+		selfIPs = []net.IP{net.ParseIP(config.upstreamHost)}
+	} else {
+		detectedIPs, err := getSelfIPAddress()
+		if err != nil {
+			return errors.Wrap(err, "failed to getSelfIPAddress")
+		}
+
+		selfIPs = detectedIPs
 	}
 
 	registerURL := fmt.Sprintf("%s/api/v1/upstream/register", config.controlPlane)


### PR DESCRIPTION
This PR adds self-registration. If a control plane is set on constd, it will detect its own V4 non-loopback private network addresses and send an upstream registration request to the control plane.