### PR TITLE
Include response headers in real sat response

### DIFF
--- a/sat/handler.go
+++ b/sat/handler.go
@@ -43,6 +43,10 @@ func (s *Sat) handler(exec *executor.Executor) vk.HandlerFunc {
 		}
 
 		resp := result.(*request.CoordinatedResponse)
+		
+		for headerKey, headerValue := range resp.RespHeaders {
+			ctx.RespHeaders.Set(headerKey, headerValue)
+		}
 
 		return resp.Output, nil
 	}


### PR DESCRIPTION
Hi there! This project looks extremely promising.

I was trying out `sat` and got quite confused about why calls to `resp::set_header` didn't seem to have any effect - my HTTP headers were not showing up on the response. On looking into it, I see they do get added to the `CoordinatedResponse` structure, but the `RespHeaders` here are simply ignored by `handler.go` and hence they don't end up in the real HTTP response.

Fortunately it's very easy to add the headers to the real HTTP response as per this PR. If there is some reason why it's intentional that the response headers should be discarded then I apologise (though it would be great if you could clarify why). Thanks!