### PR TITLE
Add binaries to sat/constd releases with GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,12 @@
-name: Testapalooza
+name: release
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
+    tags:
+      - v*
 
 jobs:
-
-  build:
-    name: Test
+  release:
     runs-on: ubuntu-latest
 
     steps:
@@ -32,12 +29,10 @@ jobs:
         run: |
           go get -v -t -d ./...
 
-      - name: Run stdin test
-        run: |
-          make sat
-          make constd
-          echo "world" | .bin/sat --stdin ./examples/hello-echo/hello-echo.wasm
-
-      - name: Run Go tests
-        run: |
-          go test -v ./...
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,42 @@
+builds:
+  - <<: &build_defaults
+      id: sat
+      main: .
+      binary: sat
+      env:
+        - CGO_ENABLED=1
+      goos:
+        - linux
+        - darwin
+      goarch:
+        - amd64
+        - arm64
+      ldflags:
+        - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+      tags:
+        - netgo
+        - wasmtime
+      overrides:
+        - goos: linux
+          ldflags:
+            - -extldflags "-static"
+  - <<: *build_defaults
+    id: constd
+    main: ./constd
+    binary: constd
+
+changelog:
+  skip: true
+
+checksum:
+  name_template: 'checksums.txt'
+
+archives:
+  - id: sat-archive
+    name_template: 'sat-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
+    builds:
+      - sat
+  - id: constd-archive
+    name_template: 'constd-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
+    builds:
+      - constd

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/suborbital/sat
 go 1.17
 
 require (
+	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/suborbital/atmo v0.4.4-0.20220222201814-da77db39d31c
 	github.com/suborbital/grav v0.5.0
@@ -18,7 +19,6 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-redis/redis/v8 v8.11.4 // indirect
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.10.1 // indirect


### PR DESCRIPTION
- Adds Linux and Darwin amd/arm64 binaries to the releases with GoReleaser
- Adds a new workflow to release the binaries
- Updates actions to v3 if available
- Adds Go mods caching to speed up actions
