### PR TITLE
Add branching at startup for stdin / service modes

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func main() {
 			conf.Logger.Error(errors.Wrap(err, "startup in StdIn"))
 			os.Exit(1)
 		}
+		os.Exit(0)
 	}
 
 	if err = run(conf); err != nil {


### PR DESCRIPTION
This is a possible solution to a [comment](https://github.com/suborbital/sat/pull/56#discussion_r834569231) by @cohix around tracing and running sat in stdin mode.