### PR TITLE
chore: simplify GoReleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,131 +1,56 @@
-env:
-  - CGO_ENABLED=1
 builds:
-  - id: sat-linux-amd64
-    main: .
-    binary: sat
-    env:
-      - CC=x86_64-linux-gnu-gcc
-      - CXX=x86_64-linux-gnu-g++
-    goos:
-      - linux
-    goarch:
-      - amd64
-    ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
-      - -extldflags "-static"
-    tags:
-      - netgo
-      - wasmtime
-  - id: sat-linux-arm64
-    main: .
-    binary: sat
-    env:
-      - CC=aarch64-linux-gnu-gcc
-      - CXX=aarch64-linux-gnu-g++
-    goos:
-      - linux
-    goarch:
-      - arm64
-    ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
-      - -extldflags "-static"
-    tags:
-      - netgo
-      - wasmtime
-  - id: sat-darwin-amd64
-    main: .
-    binary: sat
-    env:
-      - CC=o64-clang
-      - CXX=o64-clang++
-    goos:
-      - darwin
-    goarch:
-      - amd64
-    ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
-    tags:
-      - netgo
-      - wasmtime
-  - id: sat-darwin-arm64
-    main: .
-    binary: sat
-    env:
-      - CC=oa64-clang
-      - CXX=oa64-clang++
-    goos:
-      - darwin
-    goarch:
-      - arm64
-    ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
-    tags:
-      - netgo
-      - wasmtime
-
-  - id: constd-linux-amd64
+  - <<: &build_defaults
+      id: sat
+      main: .
+      binary: sat
+      env:
+        - CGO_ENABLED=1
+      goos:
+        - linux
+        - darwin
+      goarch:
+        - amd64
+        - arm64
+      tags:
+        - netgo
+        - wasmtime
+      overrides:
+        - goos: linux
+          goarch: amd64
+          goamd64: v1
+          env:
+            - CGO_ENABLED=1
+            - CC=x86_64-linux-gnu-gcc
+            - CXX=x86_64-linux-gnu-g++
+          ldflags:
+            - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+            - -extldflags "-static"
+        - goos: linux
+          goarch: arm64
+          env:
+            - CGO_ENABLED=1
+            - CC=aarch64-linux-gnu-gcc
+            - CXX=aarch64-linux-gnu-g++
+          ldflags:
+            - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+            - -extldflags "-static"
+        - goos: darwin
+          goarch: amd64
+          goamd64: v1
+          env:
+            - CGO_ENABLED=1
+            - CC=o64-clang
+            - CXX=o64-clang++
+        - goos: darwin
+          goarch: arm64
+          env:
+            - CGO_ENABLED=1
+            - CC=oa64-clang
+            - CXX=oa64-clang++
+  - <<: *build_defaults
+    id: constd
     main: ./constd
     binary: constd
-    env:
-      - CC=x86_64-linux-gnu-gcc
-      - CXX=x86_64-linux-gnu-g++
-    goos:
-      - linux
-    goarch:
-      - amd64
-    ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
-      - -extldflags "-static"
-    tags:
-      - netgo
-      - wasmtime
-  - id: constd-linux-arm64
-    main: ./constd
-    binary: constd
-    env:
-      - CC=aarch64-linux-gnu-gcc
-      - CXX=aarch64-linux-gnu-g++
-    goos:
-      - linux
-    goarch:
-      - arm64
-    ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
-      - -extldflags "-static"
-    tags:
-      - netgo
-      - wasmtime
-  - id: constd-darwin-amd64
-    main: ./constd
-    binary: constd
-    env:
-      - CC=o64-clang
-      - CXX=o64-clang++
-    goos:
-      - darwin
-    goarch:
-      - amd64
-    ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
-    tags:
-      - netgo
-      - wasmtime
-  - id: constd-darwin-arm64
-    main: ./constd
-    binary: constd
-    env:
-      - CC=oa64-clang
-      - CXX=oa64-clang++
-    goos:
-      - darwin
-    goarch:
-      - arm64
-    ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
-    tags:
-      - netgo
-      - wasmtime
 
 changelog:
   skip: true
@@ -137,14 +62,8 @@ archives:
   - id: sat
     name_template: 'sat-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     builds:
-      - sat-linux-amd64
-      - sat-linux-arm64
-      - sat-darwin-amd64
-      - sat-darwin-arm64
+      - sat
   - id: constd
     name_template: 'constd-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     builds:
-      - constd-linux-amd64
-      - constd-linux-arm64
-      - constd-darwin-amd64
-      - constd-darwin-arm64
+      - constd


### PR DESCRIPTION
With GoRelease 1.10.2+, env vars can be overriden as part of a matrix
