### PR TITLE
fix: get desiredStepState working properly

### DIFF
--- a/sat/executor/executor.go
+++ b/sat/executor/executor.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/suborbital/appspec/capabilities"
-	"github.com/suborbital/appspec/fqmn"
 	"github.com/suborbital/appspec/request"
 	"github.com/suborbital/appspec/tenant"
 	"github.com/suborbital/appspec/tenant/executable"
@@ -109,62 +108,8 @@ func (e *Executor) Register(jobType string, ref *tenant.WasmModuleRef, opts ...s
 
 // DesiredStepState calculates the state as it should be for a particular step's 'with' clause.
 func (e *Executor) DesiredStepState(step executable.Executable, req *request.CoordinatedRequest) (map[string][]byte, error) {
-	if len(step.With) == 0 {
-		return nil, ErrDesiredStateNotGenerated
-	}
-
-	desiredState := map[string][]byte{}
-	aliased := map[string]bool{}
-
-	// first go through the 'with' clause and load all of the appropriate aliased values.
-	for alias, key := range step.With {
-		val, exists := req.State[key]
-		if !exists {
-			// if the literal key is not in state,
-			// iterate through all the state keys and
-			// parse them as FQMNs, and match with any
-			// that have matching names.
-
-			found := false
-
-			for stateKey := range req.State {
-				stateFQMN, err := fqmn.Parse(stateKey)
-				if err != nil {
-					// if the state key isn't an FQMN, that's fine, move along
-					continue
-				}
-
-				if stateFQMN.Name == key {
-					found = true
-
-					val = req.State[stateKey]
-
-					desiredState[alias] = val
-					aliased[stateKey] = true
-
-					break
-				}
-			}
-
-			if !found {
-				return nil, fmt.Errorf("failed to build desired state, %s does not exists in handler state", key)
-			}
-		} else {
-			desiredState[alias] = val
-			aliased[key] = true
-		}
-
-	}
-
-	// next, go through the rest of the original state and load the non-aliased values.
-	for key, val := range req.State {
-		_, skip := aliased[key]
-		if !skip {
-			desiredState[key] = val
-		}
-	}
-
-	return desiredState, nil
+	// this is no longer needed in the Executor, will be removed from DeltaV in the future
+	return nil, ErrDesiredStateNotGenerated
 }
 
 // ListenAndRun sets up the executor's Reactr instance to listen for messages and execute the associated job.


### PR DESCRIPTION
Since Sat in meshed mode doesn't directly use the executor, its `DesiredStepState` was never run, which meant that workflows using `with` got incorrect state.

This moves the implementation out of the executor (which is an interface that'll need updating eventually), and into the wasmRunnable