### PR TITLE
chore(sat): update appspec

### DIFF
--- a/auth/access.go
+++ b/auth/access.go
@@ -1,0 +1,29 @@
+package auth
+
+import "github.com/suborbital/appspec/system"
+
+var _ system.Credential = (*AuthToken)(nil)
+
+type AuthToken struct {
+	scheme string
+	value  string
+}
+
+func (a AuthToken) Scheme() string {
+	return a.scheme
+}
+
+func (a AuthToken) Value() string {
+	return a.value
+}
+
+func NewAuthToken(token string) system.Credential {
+	if token != "" {
+		return &AuthToken{
+			scheme: "Bearer",
+			value:  token,
+		}
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/second-state/WasmEdge-go v0.9.2
 	github.com/sethvargo/go-envconfig v0.7.0
 	github.com/stretchr/testify v1.7.1
-	github.com/suborbital/appspec v0.0.2-0.20220902180808-a833dcd7ac23
+	github.com/suborbital/appspec v0.0.3
 	github.com/suborbital/deltav v0.0.0-00010101000000-000000000000
 	github.com/suborbital/vektor v0.5.3-0.20220606154347-af1e678993a8
 	github.com/testcontainers/testcontainers-go v0.13.0
@@ -38,7 +38,6 @@ require (
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v20.10.11+incompatible // indirect
 	github.com/docker/go-units v0.4.0 // indirect
-	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-redis/redis/v8 v8.11.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/second-state/WasmEdge-go v0.9.2
 	github.com/sethvargo/go-envconfig v0.7.0
 	github.com/stretchr/testify v1.7.1
+	github.com/suborbital/appspec v0.0.4-0.20220926144904-84498e00d6fc
 	github.com/suborbital/deltav v0.0.0-00010101000000-000000000000
 	github.com/suborbital/vektor v0.5.3-0.20220606154347-af1e678993a8
 	github.com/testcontainers/testcontainers-go v0.13.0
@@ -25,7 +26,6 @@ require (
 )
 
 require (
-	github.com/suborbital/appspec 84498e00d6fcc387cfd799d34775ddc57e42f82c
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Microsoft/go-winio v0.4.17 // indirect
 	github.com/Microsoft/hcsshim v0.8.23 // indirect
@@ -38,6 +38,7 @@ require (
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v20.10.11+incompatible // indirect
 	github.com/docker/go-units v0.4.0 // indirect
+	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-redis/redis/v8 v8.11.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/second-state/WasmEdge-go v0.9.2
 	github.com/sethvargo/go-envconfig v0.7.0
 	github.com/stretchr/testify v1.7.1
-	github.com/suborbital/appspec v0.0.3
 	github.com/suborbital/deltav v0.0.0-00010101000000-000000000000
 	github.com/suborbital/vektor v0.5.3-0.20220606154347-af1e678993a8
 	github.com/testcontainers/testcontainers-go v0.13.0
@@ -26,6 +25,7 @@ require (
 )
 
 require (
+	github.com/suborbital/appspec 84498e00d6fcc387cfd799d34775ddc57e42f82c
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Microsoft/go-winio v0.4.17 // indirect
 	github.com/Microsoft/hcsshim v0.8.23 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/second-state/WasmEdge-go v0.9.2
 	github.com/sethvargo/go-envconfig v0.7.0
 	github.com/stretchr/testify v1.7.1
-	github.com/suborbital/appspec v0.0.4-0.20220926144904-84498e00d6fc
+	github.com/suborbital/appspec v0.0.4-0.20220926160156-36407db9d5e1
 	github.com/suborbital/deltav v0.0.0-00010101000000-000000000000
 	github.com/suborbital/vektor v0.5.3-0.20220606154347-af1e678993a8
 	github.com/testcontainers/testcontainers-go v0.13.0
@@ -38,7 +38,6 @@ require (
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v20.10.11+incompatible // indirect
 	github.com/docker/go-units v0.4.0 // indirect
-	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-redis/redis/v8 v8.11.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -293,6 +293,7 @@ github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
+github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -731,10 +732,16 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/suborbital/appspec v0.0.1 h1:UaUPJs/rpjVfyA/4snyF+gRnVTj+HTWDj7pQ6zlYaQc=
+github.com/suborbital/appspec v0.0.1/go.mod h1:6TkMFP7jppvsJ7l3bkz30eSAo20gOd2bMbSJGLDmxIM=
+github.com/suborbital/appspec v0.0.2-0.20220902174034-7c11df87f698 h1:HPT0BCQhfHbMQPvnz2ubK82dZeofyVQ1tGfA4NoKYFY=
+github.com/suborbital/appspec v0.0.2-0.20220902174034-7c11df87f698/go.mod h1:6TkMFP7jppvsJ7l3bkz30eSAo20gOd2bMbSJGLDmxIM=
+github.com/suborbital/appspec v0.0.2-0.20220902175858-6a0656aec661 h1:tLtc8z+F1+j2aGQW0i0QxJyUECl9Fcpq1CxnXB1y3+8=
+github.com/suborbital/appspec v0.0.2-0.20220902175858-6a0656aec661/go.mod h1:6TkMFP7jppvsJ7l3bkz30eSAo20gOd2bMbSJGLDmxIM=
 github.com/suborbital/appspec v0.0.2-0.20220902180808-a833dcd7ac23 h1:QOdMwAVshiNkOJS2r4qjgcJJyj5EhQ4WYdgwjDEcDFk=
 github.com/suborbital/appspec v0.0.2-0.20220902180808-a833dcd7ac23/go.mod h1:viKHmM+uNDW+3XuZKGhZ3jZmStpomLVANscTNQVO9B0=
-github.com/suborbital/appspec v0.0.3 h1:ki+Y7V/7xSqMXJNeS5G02+iDuwKXHGLZbLbVT5itHYk=
-github.com/suborbital/appspec v0.0.3/go.mod h1:viKHmM+uNDW+3XuZKGhZ3jZmStpomLVANscTNQVO9B0=
+github.com/suborbital/appspec v0.0.4-0.20220926144904-84498e00d6fc h1:5XZtoJJwgaz1mnj/ewPix0fgLVT98U1yTo4L/xO1fZo=
+github.com/suborbital/appspec v0.0.4-0.20220926144904-84498e00d6fc/go.mod h1:viKHmM+uNDW+3XuZKGhZ3jZmStpomLVANscTNQVO9B0=
 github.com/suborbital/atmo v0.4.4-0.20220822174658-5e84e02e8737 h1:ZlnFK7KvNXqC9BPOf03hkG3hYoG0ukH3KMXGBbTQfkU=
 github.com/suborbital/atmo v0.4.4-0.20220822174658-5e84e02e8737/go.mod h1:jo+cCQ0xUJ56Pec+PNBizYlS9msAagVY8IAruEZnl0Y=
 github.com/suborbital/vektor v0.5.3-0.20220606154347-af1e678993a8 h1:1GUeXgAL4969UAg0IuZg0tKvYlsxiDd4v/MOwYIKD2U=
@@ -1011,6 +1018,7 @@ golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -293,7 +293,6 @@ github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
-github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -732,16 +731,10 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/suborbital/appspec v0.0.1 h1:UaUPJs/rpjVfyA/4snyF+gRnVTj+HTWDj7pQ6zlYaQc=
-github.com/suborbital/appspec v0.0.1/go.mod h1:6TkMFP7jppvsJ7l3bkz30eSAo20gOd2bMbSJGLDmxIM=
-github.com/suborbital/appspec v0.0.2-0.20220902174034-7c11df87f698 h1:HPT0BCQhfHbMQPvnz2ubK82dZeofyVQ1tGfA4NoKYFY=
-github.com/suborbital/appspec v0.0.2-0.20220902174034-7c11df87f698/go.mod h1:6TkMFP7jppvsJ7l3bkz30eSAo20gOd2bMbSJGLDmxIM=
-github.com/suborbital/appspec v0.0.2-0.20220902175858-6a0656aec661 h1:tLtc8z+F1+j2aGQW0i0QxJyUECl9Fcpq1CxnXB1y3+8=
-github.com/suborbital/appspec v0.0.2-0.20220902175858-6a0656aec661/go.mod h1:6TkMFP7jppvsJ7l3bkz30eSAo20gOd2bMbSJGLDmxIM=
-github.com/suborbital/appspec v0.0.2-0.20220902180808-a833dcd7ac23 h1:QOdMwAVshiNkOJS2r4qjgcJJyj5EhQ4WYdgwjDEcDFk=
-github.com/suborbital/appspec v0.0.2-0.20220902180808-a833dcd7ac23/go.mod h1:viKHmM+uNDW+3XuZKGhZ3jZmStpomLVANscTNQVO9B0=
-github.com/suborbital/appspec v0.0.4-0.20220926144904-84498e00d6fc h1:5XZtoJJwgaz1mnj/ewPix0fgLVT98U1yTo4L/xO1fZo=
-github.com/suborbital/appspec v0.0.4-0.20220926144904-84498e00d6fc/go.mod h1:viKHmM+uNDW+3XuZKGhZ3jZmStpomLVANscTNQVO9B0=
+github.com/suborbital/appspec v0.0.4-0.20220926155412-dd4778145193 h1:DLdpRhqPU9J2IXzh7xZyQKMuT800xVXCBlA6LtTAnhU=
+github.com/suborbital/appspec v0.0.4-0.20220926155412-dd4778145193/go.mod h1:viKHmM+uNDW+3XuZKGhZ3jZmStpomLVANscTNQVO9B0=
+github.com/suborbital/appspec v0.0.4-0.20220926160156-36407db9d5e1 h1:nUgraeYYibl0d24j96bmRDiSrfHwSitjsYHfNkGWPbw=
+github.com/suborbital/appspec v0.0.4-0.20220926160156-36407db9d5e1/go.mod h1:viKHmM+uNDW+3XuZKGhZ3jZmStpomLVANscTNQVO9B0=
 github.com/suborbital/atmo v0.4.4-0.20220822174658-5e84e02e8737 h1:ZlnFK7KvNXqC9BPOf03hkG3hYoG0ukH3KMXGBbTQfkU=
 github.com/suborbital/atmo v0.4.4-0.20220822174658-5e84e02e8737/go.mod h1:jo+cCQ0xUJ56Pec+PNBizYlS9msAagVY8IAruEZnl0Y=
 github.com/suborbital/vektor v0.5.3-0.20220606154347-af1e678993a8 h1:1GUeXgAL4969UAg0IuZg0tKvYlsxiDd4v/MOwYIKD2U=
@@ -1018,7 +1011,6 @@ golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -293,7 +293,6 @@ github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
-github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -732,14 +731,10 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/suborbital/appspec v0.0.1 h1:UaUPJs/rpjVfyA/4snyF+gRnVTj+HTWDj7pQ6zlYaQc=
-github.com/suborbital/appspec v0.0.1/go.mod h1:6TkMFP7jppvsJ7l3bkz30eSAo20gOd2bMbSJGLDmxIM=
-github.com/suborbital/appspec v0.0.2-0.20220902174034-7c11df87f698 h1:HPT0BCQhfHbMQPvnz2ubK82dZeofyVQ1tGfA4NoKYFY=
-github.com/suborbital/appspec v0.0.2-0.20220902174034-7c11df87f698/go.mod h1:6TkMFP7jppvsJ7l3bkz30eSAo20gOd2bMbSJGLDmxIM=
-github.com/suborbital/appspec v0.0.2-0.20220902175858-6a0656aec661 h1:tLtc8z+F1+j2aGQW0i0QxJyUECl9Fcpq1CxnXB1y3+8=
-github.com/suborbital/appspec v0.0.2-0.20220902175858-6a0656aec661/go.mod h1:6TkMFP7jppvsJ7l3bkz30eSAo20gOd2bMbSJGLDmxIM=
 github.com/suborbital/appspec v0.0.2-0.20220902180808-a833dcd7ac23 h1:QOdMwAVshiNkOJS2r4qjgcJJyj5EhQ4WYdgwjDEcDFk=
 github.com/suborbital/appspec v0.0.2-0.20220902180808-a833dcd7ac23/go.mod h1:viKHmM+uNDW+3XuZKGhZ3jZmStpomLVANscTNQVO9B0=
+github.com/suborbital/appspec v0.0.3 h1:ki+Y7V/7xSqMXJNeS5G02+iDuwKXHGLZbLbVT5itHYk=
+github.com/suborbital/appspec v0.0.3/go.mod h1:viKHmM+uNDW+3XuZKGhZ3jZmStpomLVANscTNQVO9B0=
 github.com/suborbital/atmo v0.4.4-0.20220822174658-5e84e02e8737 h1:ZlnFK7KvNXqC9BPOf03hkG3hYoG0ukH3KMXGBbTQfkU=
 github.com/suborbital/atmo v0.4.4-0.20220822174658-5e84e02e8737/go.mod h1:jo+cCQ0xUJ56Pec+PNBizYlS9msAagVY8IAruEZnl0Y=
 github.com/suborbital/vektor v0.5.3-0.20220606154347-af1e678993a8 h1:1GUeXgAL4969UAg0IuZg0tKvYlsxiDd4v/MOwYIKD2U=
@@ -1016,7 +1011,6 @@ golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/sat/access.go
+++ b/sat/access.go
@@ -1,4 +1,4 @@
-package auth
+package sat
 
 import "github.com/suborbital/appspec/system"
 

--- a/sat/config.go
+++ b/sat/config.go
@@ -19,9 +19,9 @@ import (
 	"github.com/suborbital/appspec/tenant"
 	"github.com/suborbital/deltav/fqfn"
 	"github.com/suborbital/deltav/options"
-	"github.com/suborbital/sat/auth"
 	"github.com/suborbital/vektor/vlog"
 
+	"github.com/suborbital/sat/auth"
 	satOptions "github.com/suborbital/sat/sat/options"
 )
 

--- a/sat/config.go
+++ b/sat/config.go
@@ -12,10 +12,10 @@ import (
 	"github.com/sethvargo/go-envconfig"
 	"gopkg.in/yaml.v2"
 
-	"github.com/suborbital/appspec/appsource"
-	"github.com/suborbital/appspec/appsource/client"
 	"github.com/suborbital/appspec/capabilities"
 	"github.com/suborbital/appspec/fqmn"
+	"github.com/suborbital/appspec/system"
+	"github.com/suborbital/appspec/system/client"
 	"github.com/suborbital/appspec/tenant"
 	"github.com/suborbital/deltav/fqfn"
 	"github.com/suborbital/deltav/options"
@@ -120,7 +120,7 @@ func ConfigFromRunnableArg(runnableArg string) (*Config, error) {
 			module = cpModule
 
 			// TODO: find an appropriate value for the version parameter
-			rendered, err := appsource.ResolveCapabilitiesFromSource(appClient, FQMN.Tenant, FQMN.Namespace, logger)
+			rendered, err := system.ResolveCapabilitiesFromSource(appClient, FQMN.Tenant, FQMN.Namespace, logger)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to capabilities.Render")
 			}

--- a/sat/config.go
+++ b/sat/config.go
@@ -21,7 +21,6 @@ import (
 	"github.com/suborbital/deltav/options"
 	"github.com/suborbital/vektor/vlog"
 
-	"github.com/suborbital/sat/auth"
 	satOptions "github.com/suborbital/sat/sat/options"
 )
 
@@ -89,7 +88,7 @@ func ConfigFromRunnableArg(runnableArg string) (*Config, error) {
 		useControlPlane = true
 	}
 
-	appClient := client.NewHTTPSource(controlPlane, auth.NewAuthToken(opts.EnvToken))
+	appClient := client.NewHTTPSource(controlPlane, NewAuthToken(opts.EnvToken))
 	caps := capabilities.DefaultConfigWithLogger(logger)
 
 	if useControlPlane {

--- a/sat/config.go
+++ b/sat/config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/suborbital/appspec/tenant"
 	"github.com/suborbital/deltav/fqfn"
 	"github.com/suborbital/deltav/options"
+	"github.com/suborbital/sat/auth"
 	"github.com/suborbital/vektor/vlog"
 
 	satOptions "github.com/suborbital/sat/sat/options"
@@ -88,7 +89,7 @@ func ConfigFromRunnableArg(runnableArg string) (*Config, error) {
 		useControlPlane = true
 	}
 
-	appClient := client.NewHTTPSource(controlPlane, nil)
+	appClient := client.NewHTTPSource(controlPlane, auth.NewAuthToken(opts.EnvToken))
 	caps := capabilities.DefaultConfigWithLogger(logger)
 
 	if useControlPlane {


### PR DESCRIPTION
Not 100% sure how to handle this but sat depends on atmo which depends on sat and they both have their own appspec version so they are both going to complain that the transitive dependency (appspec) isn't required. 

