### PR TITLE
chore: Remove wasmtime build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 VERSION = $(shell cat .image-ver)
 
 sat:
-	go build -o .bin/sat -tags netgo,wasmtime .
+	go build -o .bin/sat -tags netgo .
 
 sat/static:
-	go build -o .bin/sat -tags netgo,wasmtime -ldflags="-extldflags=-static" .
+	go build -o .bin/sat -tags netgo -ldflags="-extldflags=-static" .
 
 sat/install:
-	go install -tags netgo,wasmtime .
+	go install -tags netgo .
 
 docker:
 	docker build . -t suborbital/sat:dev


### PR DESCRIPTION
wasmtime is now the default and this build tag no longer exists.
